### PR TITLE
distribution: separate layer and image config for v1 pushes

### DIFF
--- a/distribution/push_v1.go
+++ b/distribution/push_v1.go
@@ -213,6 +213,7 @@ func (p *v1Pusher) imageListForTag(imgID image.ID, dependenciesSeen map[layer.Ch
 	}
 
 	topLayerID := img.RootFS.ChainID()
+	topLayer := layer.Layer(layer.EmptyLayer)
 
 	pl, err := p.config.LayerStore.Get(topLayerID)
 	*referencedLayers = append(*referencedLayers, pl)
@@ -227,9 +228,14 @@ func (p *v1Pusher) imageListForTag(imgID image.ID, dependenciesSeen map[layer.Ch
 	}
 	l := lsl.Layer
 
-	dependencyImages, parent := generateDependencyImages(l.Parent(), dependenciesSeen)
+	if l.DiffID() == layer.EmptyLayer.DiffID() {
+		topLayer = l
+		l = l.Parent()
+	}
 
-	topImage, err := newV1TopImage(imgID, img, l, parent)
+	dependencyImages, parent := generateDependencyImages(l, dependenciesSeen)
+
+	topImage, err := newV1TopImage(imgID, img, topLayer, parent)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Rebase of resin-io/docker#12
When content addressability was introduced in #17924, a compatibility layer for registry v1 pushes was added. When the engine is asked to push an image to a v1 registry it needs to create v1 IDs for the images.

The strategy so far has been to use the full imageID for the first v1 layer and the ChainID for all other layers, effectively creating as many v1 layers as there are in the image. Only the top most layer contained
the image configuration and the other layers had a dummy json containing only a parent reference.

This becomes problematic when the first layer of the image is big. Consinder the following two Dockerfiles:

```Dockerfile
FROM busybox
RUN create_very_big_file
CMD /foo
```

```Dockerfile
FROM busybox
RUN create_very_big_file
CMD /bar
```

Both of these images will have the exact same layers, with the layer created by `RUN create_very_big_file` being the topmost one, but their imageIDs will differ since they have a different CMD and therefore different image configs.

When pushing to a v1 registry, the `RUN create_very_big_file` layer will be pushed twice, once with the v1 ID set to foo's imageID and once with the v1 ID set to bar's imageID. Also, any clients wanting to pull those
images won't realise it's the same layer and will proceed to download it twice.

This commit solves this problem by separating the layers from the image configuration information when pushing to a v1 registry. To do this, all layers of an image are pushed with their ChainIDs and a synthetic top level layer is created with its contents set to the EmptyLayer, it's config set to the image config, and its v1 ID set to the imageID. This will have the side-effect of adding one layer.

To prevent new layers being piled on top of each other forever, the code checks if the topmost layer is already an empty layer and in that case it uses that for the image configuration.