### PR TITLE
daemon: return engine name as part of the version information

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -110,6 +110,7 @@ type Ping struct {
 // Version contains response of Engine API:
 // GET "/version"
 type Version struct {
+	Engine        string
 	Version       string
 	APIVersion    string `json:"ApiVersion"`
 	MinAPIVersion string `json:"MinAPIVersion,omitempty"`

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -154,6 +154,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 // SystemVersion returns version information about the daemon.
 func (daemon *Daemon) SystemVersion() types.Version {
 	v := types.Version{
+		Engine:        "balaena",
 		Version:       dockerversion.Version,
 		GitCommit:     dockerversion.GitCommit,
 		MinAPIVersion: api.MinVersion,


### PR DESCRIPTION
This can be used by clients that know how to talk to the extended API balaena provides, e.g creating deltas