### PR TITLE
fixed docker network create -d

### DIFF
--- a/vendor/github.com/docker/libnetwork/drivers_linux.go
+++ b/vendor/github.com/docker/libnetwork/drivers_linux.go
@@ -4,6 +4,7 @@ import (
 	"github.com/docker/libnetwork/drivers/bridge"
 	"github.com/docker/libnetwork/drivers/host"
 	"github.com/docker/libnetwork/drivers/null"
+	"github.com/docker/libnetwork/drivers/remote"
 )
 
 func getInitializers(experimental bool) []initializer {
@@ -11,6 +12,7 @@ func getInitializers(experimental bool) []initializer {
 		{bridge.Init, "bridge"},
 		{host.Init, "host"},
 		{null.Init, "null"},
+		{remote.Init, "remote"},
 	}
 
 	if experimental {


### PR DESCRIPTION
docker network create -d needs a remote
initializer, which was removed accidentally.

this fixes all the DockerNetworkSuite integration
tests suite.

Signed-off-by: Yossi Eliaz <yossi@resin.io>
